### PR TITLE
Fix makefile push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 push:
 	git submodule foreach git add .
-	git submodule foreach git ci -m "update resource" -a
+	git submodule foreach git commit -am "update resource"
 	git submodule foreach git push origin HEAD:gh-pages
 	git add build
 	git commit -m "update html"


### PR DESCRIPTION
## Summary
- use `git commit` instead of alias in the `push` command

## Testing
- `make -n push`

------
https://chatgpt.com/codex/tasks/task_e_687bca097fb48329be771bfb0d1e1182