### PR TITLE
Add manual trigger for Sphinx docs build

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
   # pull_request:
   #   branches:
   #     - master


### PR DESCRIPTION
## Summary
- enable `workflow_dispatch` on Sphinx build workflow

## Testing
- `python` syntax check for `.github/workflows/build-sphinx.yml`


------
https://chatgpt.com/codex/tasks/task_e_687d0a72491c83298f057f1b019731dc